### PR TITLE
Fix ProgressChanNoWait and add JobQueryOption support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# git history files
+.history_rewritten_*
+
+# project artifacts
+.project
+
+# Intellij
+*.iml
+.idea
+
+# Visual Studio Code
+.vscode
+
+# vi backups
+*.bak
+
+# Golang
+.testCoverage.txt
+.testPkg.txt
+


### PR DESCRIPTION
The `ProgressChanNoWait` function on the master branch will cause random results, for example

This code below, in which calling the `ProgressChanNoWait` function, have no repeatble results
```
func TestProcessNoWait(t *testing.T) {
	j := NewJobQuery()
	c := j.ProgressChanNoWait("v1")

	for i := 0; i < 10; i++ {
		c <- strconv.Itoa(i)
	}

	time.Sleep(time.Microsecond * 100)
	close(j.done)
	j.wg.Wait()
}
```

Since the [select statement](https://golang.org/ref/spec#Select_statements) mechanism,  randomly it will have no chance to call `SetProgress`.